### PR TITLE
ci(dependabot): schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,10 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+      day: 'saturday'
+      time: '10:00'
+      timezone: 'Asia/Tokyo'
     assignees:
       - 'jnicrimi'
     reviewers:
@@ -13,7 +16,10 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+      day: 'saturday'
+      time: '10:00'
+      timezone: 'Asia/Tokyo'
     assignees:
       - 'jnicrimi'
     reviewers:


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Chore: `.github/dependabot.yml`の設定を更新しました。npmとgithub-actionsパッケージエコシステムのアップデートスケジュールを毎日から毎週に変更し、曜日を土曜日に設定し、時間を10:00に設定し、タイムゾーンをAsia/Tokyoに設定しました。これにより、開発者は最新の依存関係を維持するための作業を効率化できます。また、'jnicrimi'がレビューを担当します。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->